### PR TITLE
Drag & Drop and animations

### DIFF
--- a/ChuanhuWallpaper.xcodeproj/project.pbxproj
+++ b/ChuanhuWallpaper.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		129D35522971603100240248 /* AddPictureButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 129D35512971603100240248 /* AddPictureButton.swift */; };
 		12BF6A5829704133001F0EB4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12BF6A5729704133001F0EB4 /* AppDelegate.swift */; };
 		38273E842982C993002433F9 /* WallpapperLib in Frameworks */ = {isa = PBXBuildFile; productRef = 38273E832982C993002433F9 /* WallpapperLib */; };
+		38273E8629838107002433F9 /* WallPaperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38273E8529838107002433F9 /* WallPaperView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,6 +45,7 @@
 		129D354D29715C2400240248 /* SubmitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitButton.swift; sourceTree = "<group>"; };
 		129D35512971603100240248 /* AddPictureButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPictureButton.swift; sourceTree = "<group>"; };
 		12BF6A5729704133001F0EB4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		38273E8529838107002433F9 /* WallPaperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WallPaperView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -107,6 +109,7 @@
 				1207B47E296EF60200B5D36D /* ContentView.swift */,
 				1207B494296EF74B00B5D36D /* SolarWallpaperView.swift */,
 				1207B496296EF75F00B5D36D /* TimeWallpaperView.swift */,
+				38273E8529838107002433F9 /* WallPaperView.swift */,
 				1207B498296EF77000B5D36D /* AppearanceWallpaperView.swift */,
 			);
 			name = View;
@@ -212,6 +215,7 @@
 			files = (
 				12BF6A5829704133001F0EB4 /* AppDelegate.swift in Sources */,
 				129D354E29715C2400240248 /* SubmitButton.swift in Sources */,
+				38273E8629838107002433F9 /* WallPaperView.swift in Sources */,
 				1207B499296EF77000B5D36D /* AppearanceWallpaperView.swift in Sources */,
 				1207B49B296F09F000B5D36D /* ImageModel.swift in Sources */,
 				129D35522971603100240248 /* AddPictureButton.swift in Sources */,

--- a/ChuanhuWallpaper/AppearanceWallpaperView.swift
+++ b/ChuanhuWallpaper/AppearanceWallpaperView.swift
@@ -10,7 +10,8 @@ import FilePicker
 import WallpapperLib
 
 struct AppearanceWallpaperView: View {
-    @State var wallpapers: [WallpaperImage] = [WallpaperImage(fileName: "noimage.jpg", isFor: .light), WallpaperImage(fileName: "noimage.jpg", isFor: .dark)]
+    @State private var lightWallpaper = WallpaperImage(fileName: "noimage.jpg", isFor: .light)
+    @State private var darkWallpaper = WallpaperImage(fileName: "noimage.jpg", isFor: .dark)
     @State var pictureInfos: [PictureInfo] = []
     @State var showErrorMessage = false
     @State var errorMessage = ""
@@ -19,60 +20,78 @@ struct AppearanceWallpaperView: View {
     
     var body: some View {
         VStack {
-            ScrollView{
-                HStack {
-                    Spacer()
-                    Image(nsImage: NSImage(contentsOfFile: wallpapers[0].fileName) ?? NSImage(imageLiteralResourceName: "noimage.jpg"))
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 150, height: 150)
-                    VStack(alignment: .leading) {
-                        Text("Light Image")
-                            .font(.headline)
-                        //                    Text(wallpapers[0].fileName)
-                        Toggle("Is Primary", isOn: self.$wallpapers[0].isPrimary)
-                        FilePicker(types: [.image], allowMultiple: false) { urls in
-                            let filepath = urls[0].path
-                            wallpapers[0].fileName = filepath.removingPercentEncoding!
-                            currentSelectedNum += 1
-                        } label: {
-                            Label("Change Picture", systemImage: "doc.badge.plus")
-                        }
-                    }
-                    Spacer()
-                }
-                HStack {
-                    Spacer()
-                    Image(nsImage: NSImage(contentsOfFile: wallpapers[1].fileName) ?? NSImage(imageLiteralResourceName: "noimage.jpg"))
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 150, height: 150)
-                    Form {
-                        Text("Dark Image")
-                            .font(.headline)
-                        Toggle("Is Primary", isOn: self.$wallpapers[1].isPrimary)
-                        FilePicker(types: [.image], allowMultiple: false) { urls in
-                            let filepath = urls[0].path
-                            wallpapers[1].fileName = filepath
-                            currentSelectedNum += 1
-                        } label: {
-                            Label("Change Picture", systemImage: "doc.badge.plus")
-                        }
-                    }
-                    Spacer()
-                }
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.bottom)
+            light
+            dark
         }
         .toolbar {
+            let wallpapers = [lightWallpaper, darkWallpaper]
             SubmitButton(wallpapers: wallpapers).disabled(currentSelectedNum < 2)
+        }
+    }
+    
+    var light: some View {
+        HStack {
+            Image(nsImage: NSImage(contentsOfFile: lightWallpaper.fileName) ?? NSImage(imageLiteralResourceName: "noimage.jpg"))
+                .resizable()
+                .scaledToFit()
+                .frame(width: 150, height: 150)
+            VStack(alignment: .leading) {
+                Text("Light Image")
+                    .font(.headline)
+                Toggle("Is Primary", isOn: self.$lightWallpaper.isPrimary)
+                FilePicker(types: [.image], allowMultiple: false) { urls in
+                    let filepath = urls[0].path
+                    lightWallpaper.fileName = filepath.removingPercentEncoding!
+                    currentSelectedNum += 1
+                } label: {
+                    Label("Change Picture", systemImage: "doc.badge.plus")
+                }
+            }
+        }
+        .onDrop(of: [.image, .jpeg, .png], isTargeted: .constant(false)) { providers in
+            providers[0].loadInPlaceFileRepresentation(forTypeIdentifier: "public.image") { url, _, _ in
+                if let url {
+                    lightWallpaper.fileName = url.path
+                    currentSelectedNum += 1
+                }
+            }
+            return true
+        }
+    }
+    
+    var dark: some View {
+        HStack {
+            Image(nsImage: NSImage(contentsOfFile: darkWallpaper.fileName) ?? NSImage(imageLiteralResourceName: "noimage.jpg"))
+                .resizable()
+                .scaledToFit()
+                .frame(width: 150, height: 150)
+            Form {
+                Text("Dark Image")
+                    .font(.headline)
+                Toggle("Is Primary", isOn: self.$darkWallpaper.isPrimary)
+                FilePicker(types: [.image], allowMultiple: false) { urls in
+                    let filepath = urls[0].path
+                    darkWallpaper.fileName = filepath
+                    currentSelectedNum += 1
+                } label: {
+                    Label("Change Picture", systemImage: "doc.badge.plus")
+                }
+            }
+        }
+        .onDrop(of: [.image, .jpeg, .png], isTargeted: .constant(false)) { providers in
+            providers[0].loadInPlaceFileRepresentation(forTypeIdentifier: "public.image") { url, _, _ in
+                if let url {
+                    darkWallpaper.fileName = url.path
+                    currentSelectedNum += 1
+                }
+            }
+            return true
         }
     }
 }
 
 struct AppearanceWallpaperView_Previews: PreviewProvider {
     static var previews: some View {
-        AppearanceWallpaperView(wallpapers: [WallpaperImage(fileName: "noimage.jpg", isFor: .light), WallpaperImage(fileName: "noimage.jpg", isFor: .dark)])
+        AppearanceWallpaperView()
     }
 }

--- a/ChuanhuWallpaper/AppearanceWallpaperView.swift
+++ b/ChuanhuWallpaper/AppearanceWallpaperView.swift
@@ -66,9 +66,7 @@ struct AppearanceWallpaperView: View {
             .padding(.bottom)
         }
         .toolbar {
-            ToolbarItemGroup {
-                SubmitButton(wallpapers: wallpapers, disableSubmit: currentSelectedNum < 2)
-            }
+            SubmitButton(wallpapers: wallpapers).disabled(currentSelectedNum < 2)
         }
     }
 }

--- a/ChuanhuWallpaper/ContentView.swift
+++ b/ChuanhuWallpaper/ContentView.swift
@@ -46,23 +46,6 @@ struct ContentView: View {
             }
             .listStyle(.sidebar)
         }
-//        TabView {
-//            AppearanceWallpaperView()
-//                .tabItem {
-//                    Label("Appearance", systemImage: "star")
-//                }
-//                .tag(Tabs.appearance)
-//            SolarWallpaperView()
-//                .tabItem {
-//                    Label("Solar", systemImage: "gear")
-//                }
-//                .tag(Tabs.solar)
-//            TimeWallpaperView()
-//                .tabItem {
-//                    Label("Time", systemImage: "star")
-//                }
-//                .tag(Tabs.time)
-//        }
     }
 }
 

--- a/ChuanhuWallpaper/SolarWallpaperView.swift
+++ b/ChuanhuWallpaper/SolarWallpaperView.swift
@@ -13,120 +13,91 @@ struct SolarWallpaperView: View {
     @State var wallpapers: [WallpaperImage] = []
     @State var showErrorMessage = false
     @State var errorMessage = ""
-    @State var showPopover = false
-    var numbers: [Int] {
-        let numbers: [Int] = Array(0..<wallpapers.count)
-        return numbers
-    }
     let wallpaperGenerator = WallpaperGenerator()
     
     var body: some View {
-        VStack {
-            ScrollView {
-                VStack {
-                    if(wallpapers.count == 0){
-                        Spacer()
-                        Text("No images yet.")
-                            .foregroundColor(.secondary)
-                    }
-                    ForEach(wallpapers.indices, id: \.self) { index in
-                        let wallpaper = Binding<WallpaperImage> {
-                            wallpapers[index]
-                        } set: {
-                            wallpapers[min(index, wallpapers.count - 1)] = $0
-                        }
-                        let wrappedWallpaper = wallpaper.wrappedValue
-                        HStack {
-                            Image(nsImage: NSImage(contentsOfFile: wrappedWallpaper.fileName) ?? NSImage(imageLiteralResourceName: "noimage.jpg"))
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 150, height: 150)
-                                .padding(.trailing)
-                            Form {
-                                Toggle("Is Primary", isOn: wallpaper.isPrimary)
-                                Picker("Is For:", selection: wallpaper.isFor) {
-                                    Text("Dark").tag(WallpaperAppearance.dark)
-                                    Text("Light").tag(WallpaperAppearance.light)
-                                    Text("None").tag(WallpaperAppearance.none)
-                                }
-                                // Crashes here. (Start)
-                                TextField("Altitude", value: wallpaper.altitude, formatter: NumberFormatter())
-                                TextField("Azimuth", value: wallpaper.azimuth, formatter: NumberFormatter())
-                                // Crashes here. (End)
-                                HStack {
-                                    Spacer()
-                                    Button {
-                                        wallpapers.swapAt(index, index-1)
-                                    } label: {
-                                        Text("Move Up")
-                                    }
-                                    .disabled(index == 0)
-                                    Button {
-                                        wallpapers.swapAt(index, index+1)
-                                    } label: {
-                                        Text("Move Down")
-                                    }
-                                    .disabled(index == wallpapers.count-1)
-                                    Button {
-                                        wallpapers.remove(at: index)
-                                    } label: {
-                                        Text("Trash")
-                                    }
-                                }
-                            }
-                            .frame(maxWidth: 300)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                    }
-                }
-                .padding(.bottom)
+        Group {
+            if wallpapers.isEmpty {
+                noWallpapers
+            } else {
+                wallpapersList
             }
         }
-        .toolbar {
-            ToolbarItemGroup {
-                HelpButton {
-                    self.showPopover.toggle()
-                }
-                .popover(isPresented: self.$showPopover, arrowEdge: .bottom) {
-                    VStack {
-                        Text("The primary image will be visible after creating heic file. \nIf image was set to Light, it will be displayed when user chose \"Light (static)\" wallpaper. The same happened when set to Dark. \nAltitude is the angle between the Sun and the observer's local horizon. Azimuth  is the angle of the Sun around the horizon.")
-                    }
-                    .frame(width: 200)
-                    .padding()
-                }
-                FilePicker(types: [.image], allowMultiple: false) { urls in
-                    let fileURL = urls[0]
-                    do {
-                        let inputFileContents = try Data(contentsOf: fileURL)
-                        let locationExtractor = LocationExtractor()
-                        let imageLocation = try locationExtractor.extract(imageData: inputFileContents)
-                        let sunCalculations = SunCalculations(imageLocation: imageLocation)
-                        let position = sunCalculations.getSunPosition()
-                        wallpapers.append(WallpaperImage(fileName: fileURL.path, altitude: position.altitude, azimuth: position.azimuth))
-                    } catch (let error) where "\(error)" == "missingLatitude" {
-                        wallpapers.append(WallpaperImage(fileName: fileURL.path))
-                    } catch (let error as WallpapperError) {
-                        showErrorMessage = true
-                        errorMessage = "Unexpected error occurs: \(error.message)"
-                    } catch {
-                        showErrorMessage = true
-                        errorMessage = "oops: \(error)"
-                    }
-                } label: {
-                    ZStack {
-                        Image(systemName: "photo.on.rectangle")
-                        Image(systemName: "plus.circle.fill")
-                            .font(.system(size: 8))
-                            .offset(x:8,y:-5)
-                    }
-                    Text("Add New Picture")
-                    //Label("Add New Picture", systemImage: "doc.badge.plus")
-                }
-                SubmitButton(wallpapers: wallpapers, disableSubmit: wallpapers.count < 2)
-            }
-        }
+        .toolbar(content: toolbar)
         .navigationSubtitle(String(wallpapers.count) + " image(s)")
+    }
+    
+    var noWallpapers: some View {
+        Text("No images yet.")
+            .font(.title2.bold())
+            .foregroundColor(.secondary)
+    }
+    
+    var wallpapersList: some View {
+        ScrollView {
+            VStack {
+                ForEach($wallpapers, id: \.id) { wallpaper in
+                    WallPaperView(wallpapers: $wallpapers, wallpaper: wallpaper, type: .solar)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            .padding()
+        }
+    }
+}
+
+extension SolarWallpaperView {
+    @ToolbarContentBuilder
+    func toolbar() -> some ToolbarContent {
+        ToolbarItemGroup {
+            HelpButton {
+                Text("The primary image will be visible after creating heic file. \nIf image was set to Light, it will be displayed when user chose \"Light (static)\" wallpaper. The same happened when set to Dark. \nAltitude is the angle between the Sun and the observer's local horizon. Azimuth  is the angle of the Sun around the horizon.")
+                    .frame(width: 200)
+            }
+            
+            FilePicker(types: [.image], allowMultiple: true) { urls in
+                for url in urls {
+                    if addWallpaper(at: url) == false {
+                        // Failed to add wallpaper / one of the wallpapers.
+                        // Discard all the wallpapers after that.
+                        return
+                    }
+                }
+            } label: {
+                ZStack {
+                    Image(systemName: "photo.on.rectangle")
+                    Image(systemName: "plus.circle.fill")
+                        .font(.system(size: 8))
+                        .offset(x:8,y:-5)
+                }
+                Text("Add New Picture")
+                //Label("Add New Picture", systemImage: "doc.badge.plus")
+            }
+            SubmitButton(wallpapers: wallpapers).disabled(wallpapers.count < 2)
+        }
+    }
+    
+    private func addWallpaper(at url: URL) -> Bool {
+        do {
+            let inputFileContents = try Data(contentsOf: url)
+            let locationExtractor = LocationExtractor()
+            let imageLocation = try locationExtractor.extract(imageData: inputFileContents)
+            let sunCalculations = SunCalculations(imageLocation: imageLocation)
+            let position = sunCalculations.getSunPosition()
+            wallpapers.append(WallpaperImage(fileName: url.path, altitude: position.altitude, azimuth: position.azimuth))
+            return true
+        } catch (let error) where "\(error)" == "missingLatitude" {
+            wallpapers.append(WallpaperImage(fileName: url.path))
+            return true
+        } catch (let error as WallpapperError) {
+            showErrorMessage = true
+            errorMessage = "Unexpected error occurs: \(error.message)"
+            return false
+        } catch {
+            showErrorMessage = true
+            errorMessage = "oops: \(error)"
+            return false
+        }
     }
 }
 

--- a/ChuanhuWallpaper/SolarWallpaperView.swift
+++ b/ChuanhuWallpaper/SolarWallpaperView.swift
@@ -13,6 +13,7 @@ struct SolarWallpaperView: View {
     @State var wallpapers: [WallpaperImage] = []
     @State var showErrorMessage = false
     @State var errorMessage = ""
+    @State private var dropTarget = false
     let wallpaperGenerator = WallpaperGenerator()
     
     var body: some View {
@@ -23,6 +24,19 @@ struct SolarWallpaperView: View {
                 wallpapersList
             }
         }
+        .overlay(dropPlaceholder)
+        .onDrop(of: [.jpeg, .image, .png], isTargeted: $dropTarget) { providers in
+            for provider in providers {
+                provider.loadInPlaceFileRepresentation(forTypeIdentifier: "public.image") { url, _, _ in
+                    if let url {
+                        if addWallpaper(at: url) == false {
+                            return
+                        }
+                    }
+                }
+            }
+            return true
+        }
         .toolbar(content: toolbar)
         .navigationSubtitle(String(wallpapers.count) + " image(s)")
     }
@@ -31,6 +45,7 @@ struct SolarWallpaperView: View {
         Text("No images yet.")
             .font(.title2.bold())
             .foregroundColor(.secondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
     
     var wallpapersList: some View {
@@ -42,6 +57,15 @@ struct SolarWallpaperView: View {
                 }
             }
             .padding()
+        }
+    }
+    
+    @ViewBuilder
+    var dropPlaceholder: some View {
+        if dropTarget {
+            Rectangle()
+                .stroke(Color.secondary, style: StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round, miterLimit: 0, dash: [10], dashPhase: 0))
+                .padding(5)
         }
     }
 }

--- a/ChuanhuWallpaper/SubmitButton.swift
+++ b/ChuanhuWallpaper/SubmitButton.swift
@@ -13,7 +13,6 @@ struct SubmitButton: View {
     @State var showErrorMessage = false
     @State var errorMessage = ""
     let wallpaperGenerator = WallpaperGenerator()
-    var disableSubmit = false
     
     var body: some View {
         Button {
@@ -42,7 +41,6 @@ struct SubmitButton: View {
         .alert(isPresented: $showErrorMessage) {
             Alert(title: Text("An Error Occured"), message: Text(errorMessage), dismissButton: .cancel())
         }
-        .disabled(disableSubmit)
     }
 }
 

--- a/ChuanhuWallpaper/TimeWallpaperView.swift
+++ b/ChuanhuWallpaper/TimeWallpaperView.swift
@@ -14,114 +14,88 @@ struct TimeWallpaperView: View {
     @State var pictureInfos: [PictureInfo] = []
     @State var showErrorMessage = false
     @State var errorMessage = ""
-    @State var showPopover = false
     let wallpaperGenerator = WallpaperGenerator()
     
     var body: some View {
-        VStack {
-            ScrollView {
-                VStack {
-                    if(wallpapers.count == 0){
-                        Spacer()
-                        Text("No images yet.")
-                            .foregroundColor(.secondary)
-                    }
-                    ForEach(wallpapers.indices, id: \.self) { index in
-                        let wallpaper = Binding<WallpaperImage> {
-                            wallpapers[index]
-                        } set: {
-                            wallpapers[min(index, wallpapers.count - 1)] = $0
-                        }
-                        let wrappedWallpaper = wallpaper.wrappedValue
-                        HStack {
-                            Image(nsImage: NSImage(contentsOfFile: wrappedWallpaper.fileName) ?? NSImage(imageLiteralResourceName: "noimage.jpg"))
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: 150, height: 150)
-                                .padding(.trailing)
-                            Form {
-                                Toggle("Is Primary", isOn: wallpaper.isPrimary)
-                                Picker("Is For:", selection: wallpaper.isFor) {
-                                    Text("Dark").tag(WallpaperAppearance.dark)
-                                    Text("Light").tag(WallpaperAppearance.light)
-                                    Text("None").tag(WallpaperAppearance.none)
-                                }
-                                DatePicker(selection: wallpaper.time, label: { Text("Time") })
-                                HStack {
-                                    Spacer()
-                                    Button {
-                                        wallpapers.swapAt(index, index-1)
-                                    } label: {
-                                        Text("Move Up")
-                                    }
-                                    .disabled(index == 0)
-                                    Button {
-                                        wallpapers.swapAt(index, index+1)
-                                    } label: {
-                                        Text("Move Down")
-                                    }
-                                    .disabled(index == wallpapers.count-1)
-                                    Button {
-                                        wallpapers.remove(at: index)
-                                    } label: {
-                                        Text("Trash")
-                                    }
-                                }
-                            }
-                            .frame(maxWidth: 300)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                    }
-                }
-                .padding(.bottom)
+        Group {
+            if wallpapers.isEmpty {
+                noWallpapers
+            } else {
+                wallpapersList
             }
         }
-        .toolbar {
-            ToolbarItemGroup {
-                HelpButton {
-                    self.showPopover.toggle()
-                }
-                .popover(isPresented: self.$showPopover, arrowEdge: .bottom) {
-                    VStack {
-                        Text("Pictures switch based on OS time. \nIf set to primary, the image will be visible after creating the heic file. \nIf set to \"is for Light\", picture will be displayed when user chose \"Light (static)\". The same is true for \"is for Dark\". \nTime is most relevant in hour.")
-                    }
-                    .frame(width: 200)
-                    .padding()
-                }
-                FilePicker(types: [.image], allowMultiple: false) { urls in
-                    //                    if let filepath = urls[0].path().removingPercentEncoding{
-                    //                        wallpapers.append(WallpaperImage(fileName: filepath))
-                    //                    }
-                    let fileURL = urls[0]
-                    do {
-                        let inputFileContents = try Data(contentsOf: fileURL)
-                        let locationExtractor = LocationExtractor()
-                        let imageCreateDate = try locationExtractor.extractTime(imageData: inputFileContents)
-                        wallpapers.append(WallpaperImage(fileName: fileURL.path, time: imageCreateDate))
-                    } catch (let error) where "\(error)" == "missingCreationDate" {
-                        wallpapers.append(WallpaperImage(fileName: fileURL.path))
-                    } catch (let error as WallpapperError) {
-                        showErrorMessage = true
-                        errorMessage = "Unexpected error occurs: \(error)"
-                    } catch {
-                        showErrorMessage = true
-                        errorMessage = "oops: \(error)"
-                    }
-                } label: {
-                    ZStack {
-                        Image(systemName: "photo.on.rectangle")
-                        Image(systemName: "plus.circle.fill")
-                            .font(.system(size: 8))
-                            .offset(x:8,y:-5)
-                    }
-                    Text("Add New Picture")
-                    //Label("Add New Picture", systemImage: "doc.badge.plus")
-                }
-                SubmitButton(wallpapers: wallpapers, disableSubmit: wallpapers.count < 2)
-            }
-        }
+        .toolbar(content: toolbar)
         .navigationSubtitle("\(wallpapers.count) image(s)")
+    }
+    
+    var noWallpapers: some View {
+        Text("No images yet.")
+            .font(.title2.bold())
+            .foregroundColor(.secondary)
+    }
+    
+    var wallpapersList: some View {
+        ScrollView {
+            VStack {
+                ForEach($wallpapers, id: \.id) { wallpaper in
+                    WallPaperView(wallpapers: $wallpapers, wallpaper: wallpaper, type: .time)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            .padding()
+        }
+    }
+}
+
+extension TimeWallpaperView {
+    @ToolbarContentBuilder
+    func toolbar() -> some ToolbarContent {
+        ToolbarItemGroup {
+            HelpButton {
+                Text("Pictures switch based on OS time. \nIf set to primary, the image will be visible after creating the heic file. \nIf set to \"is for Light\", picture will be displayed when user chose \"Light (static)\". The same is true for \"is for Dark\". \nTime is most relevant in hour.")
+                    .frame(width: 200)
+            }
+            FilePicker(types: [.image], allowMultiple: true) { urls in
+                for url in urls {
+                    if addWallpaper(at: url) == false {
+                        // Failed to add wallpaper / one of the wallpapers.
+                        // Discard all the wallpapers after that.
+                        return
+                    }
+                }
+            } label: {
+                ZStack {
+                    Image(systemName: "photo.on.rectangle")
+                    Image(systemName: "plus.circle.fill")
+                        .font(.system(size: 8))
+                        .offset(x:8,y:-5)
+                }
+                Text("Add New Picture")
+                //Label("Add New Picture", systemImage: "doc.badge.plus")
+            }
+            SubmitButton(wallpapers: wallpapers).disabled(wallpapers.count < 2)
+        }
+    }
+    
+    private func addWallpaper(at url: URL) -> Bool {
+        do {
+            let inputFileContents = try Data(contentsOf: url)
+            let locationExtractor = LocationExtractor()
+            let imageCreateDate = try locationExtractor.extractTime(imageData: inputFileContents)
+            wallpapers.append(WallpaperImage(fileName: url.path, time: imageCreateDate))
+            return true
+        } catch (let error) where "\(error)" == "missingCreationDate" {
+            wallpapers.append(WallpaperImage(fileName: url.path))
+            return true
+        } catch (let error as WallpapperError) {
+            showErrorMessage = true
+            errorMessage = "Unexpected error occurs: \(error)"
+            return false
+        } catch {
+            showErrorMessage = true
+            errorMessage = "oops: \(error)"
+            return false
+        }
     }
 }
 

--- a/ChuanhuWallpaper/TimeWallpaperView.swift
+++ b/ChuanhuWallpaper/TimeWallpaperView.swift
@@ -14,6 +14,7 @@ struct TimeWallpaperView: View {
     @State var pictureInfos: [PictureInfo] = []
     @State var showErrorMessage = false
     @State var errorMessage = ""
+    @State var dropTarget = false
     let wallpaperGenerator = WallpaperGenerator()
     
     var body: some View {
@@ -24,6 +25,19 @@ struct TimeWallpaperView: View {
                 wallpapersList
             }
         }
+        .overlay(dropPlaceholder)
+        .onDrop(of: [.jpeg, .image, .png], isTargeted: $dropTarget) { providers in
+            for provider in providers {
+                provider.loadInPlaceFileRepresentation(forTypeIdentifier: "public.image") { url, _, _ in
+                    if let url {
+                        if addWallpaper(at: url) == false {
+                            return
+                        }
+                    }
+                }
+            }
+            return true
+        }
         .toolbar(content: toolbar)
         .navigationSubtitle("\(wallpapers.count) image(s)")
     }
@@ -32,6 +46,7 @@ struct TimeWallpaperView: View {
         Text("No images yet.")
             .font(.title2.bold())
             .foregroundColor(.secondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
     
     var wallpapersList: some View {
@@ -43,6 +58,15 @@ struct TimeWallpaperView: View {
                 }
             }
             .padding()
+        }
+    }
+    
+    @ViewBuilder
+    var dropPlaceholder: some View {
+        if dropTarget {
+            Rectangle()
+                .stroke(Color.secondary, style: StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round, miterLimit: 0, dash: [10], dashPhase: 0))
+                .padding(5)
         }
     }
 }

--- a/ChuanhuWallpaper/UsefulFunctions.swift
+++ b/ChuanhuWallpaper/UsefulFunctions.swift
@@ -38,20 +38,26 @@ func loadImageFromDiskWith(fileName: String) -> NSImage? {
     return nil
 }
 
-struct HelpButton: View {
-    var action : () -> Void
+struct HelpButton<Popover: View>: View {
+    @State private var showPopover = false
+    var content: () -> Popover
 
     var body: some View {
-        Button(action: action, label: {
+        Button {
+            showPopover.toggle()
+        } label: {
             ZStack {
                 Circle()
                     .strokeBorder(Color(NSColor.separatorColor), lineWidth: 0.5)
                     .background(Circle().foregroundColor(Color(NSColor.controlColor)))
                     .shadow(color: Color(NSColor.separatorColor).opacity(0.3), radius: 1)
                     .frame(width: 20, height: 20)
-                Text("?").font(.system(size: 15, weight: .medium ))
+                Text("?").font(.system(size: 15, weight: .medium))
             }
-        })
+        }
         .buttonStyle(PlainButtonStyle())
+        .popover(isPresented: $showPopover, arrowEdge: .bottom) {
+            content().padding()
+        }
     }
 }

--- a/ChuanhuWallpaper/WallPaperView.swift
+++ b/ChuanhuWallpaper/WallPaperView.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 
 struct WallPaperView: View {
+    // Store the image inside a State to animate the image.
+    // To learn more about SwiftUI refresh pattern, watch `Demystify SwiftUI` from WWDC 2021.
+    @State private var image: Image = Image(nsImage: NSImage(imageLiteralResourceName: "noimage.jpeg"))
     @Binding var wallpapers: [WallpaperImage]
     @Binding var wallpaper: WallpaperImage
     var index: Int {
@@ -22,7 +25,7 @@ struct WallPaperView: View {
     
     var body: some View {
         HStack {
-            Image(nsImage: NSImage(contentsOfFile: wallpaper.fileName) ?? NSImage(imageLiteralResourceName: "noimage.jpg"))
+            image
                 .resizable()
                 .scaledToFit()
                 .frame(width: 150, height: 150)
@@ -45,6 +48,11 @@ struct WallPaperView: View {
             }
             .frame(maxWidth: 300)
         }
+        .onAppear {
+            if let nsImage = NSImage(contentsOfFile: wallpaper.fileName) {
+                image = Image(nsImage: nsImage)
+            }
+        }
     }
     
     @ViewBuilder
@@ -53,19 +61,25 @@ struct WallPaperView: View {
             HStack {
                 Spacer()
                 Button {
-                    wallpapers.swapAt(index, index-1)
+                    withAnimation {
+                        wallpapers.swapAt(index, index - 1)
+                    }
                 } label: {
                     Text("Move Up")
                 }
                 .disabled(index == 0)
                 Button {
-                    wallpapers.swapAt(index, index+1)
+                    withAnimation {
+                        wallpapers.swapAt(index, index + 1)
+                    }
                 } label: {
                     Text("Move Down")
                 }
-                .disabled(index == wallpapers.count-1)
+                .disabled(index == wallpapers.count - 1)
                 Button {
-                    wallpapers.remove(at: index)
+                    withAnimation {
+                        _ = wallpapers.remove(at: index)
+                    }
                 } label: {
                     Text("Trash")
                 }

--- a/ChuanhuWallpaper/WallPaperView.swift
+++ b/ChuanhuWallpaper/WallPaperView.swift
@@ -1,0 +1,75 @@
+//
+//  WallPaperView.swift
+//  ChuanhuWallpaper
+//
+//  Created by LiYanan2004 on 2023/1/27.
+//
+
+import SwiftUI
+
+struct WallPaperView: View {
+    @Binding var wallpapers: [WallpaperImage]
+    @Binding var wallpaper: WallpaperImage
+    var index: Int {
+        wallpapers.firstIndex(of: wallpaper) ?? -1
+    }
+    
+    var type: WallPaperType
+    enum WallPaperType {
+        case time
+        case solar
+    }
+    
+    var body: some View {
+        HStack {
+            Image(nsImage: NSImage(contentsOfFile: wallpaper.fileName) ?? NSImage(imageLiteralResourceName: "noimage.jpg"))
+                .resizable()
+                .scaledToFit()
+                .frame(width: 150, height: 150)
+                .padding(.trailing)
+            VStack {
+                Toggle("Is Primary", isOn: $wallpaper.isPrimary)
+                Picker("Is For:", selection: $wallpaper.isFor) {
+                    Text("Dark").tag(WallpaperAppearance.dark)
+                    Text("Light").tag(WallpaperAppearance.light)
+                    Text("None").tag(WallpaperAppearance.none)
+                }
+                switch type {
+                case .solar:
+                    TextField("Altitude", value: $wallpaper.altitude, formatter: NumberFormatter())
+                    TextField("Azimuth", value: $wallpaper.azimuth, formatter: NumberFormatter())
+                case .time:
+                    DatePicker("Time", selection: $wallpaper.time)
+                }
+                buttons
+            }
+            .frame(maxWidth: 300)
+        }
+    }
+    
+    @ViewBuilder
+    var buttons: some View {
+        if index >= 0 {
+            HStack {
+                Spacer()
+                Button {
+                    wallpapers.swapAt(index, index-1)
+                } label: {
+                    Text("Move Up")
+                }
+                .disabled(index == 0)
+                Button {
+                    wallpapers.swapAt(index, index+1)
+                } label: {
+                    Text("Move Down")
+                }
+                .disabled(index == wallpapers.count-1)
+                Button {
+                    wallpapers.remove(at: index)
+                } label: {
+                    Text("Trash")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 简化代码

给川虎壁纸的代码做了一波处理，三大 View 看起来都更加的清爽了

将 Solar 和 Time 中的每一个壁纸块作为一个个的 cell 分离到了 WallPaperView 中。

## 增加 Drag & Drop 支持

可以一次性从文件夹中拖拽图片出来，批量导入，

亮暗色支持拖动到对应的颜色模式，

悄悄的说，从 app 导航栏按钮导入也可以多张一起啦～

## 动画

动作按钮，例如上/下移，删除都支持动画啦～

## 小变化

没有图片的时候默认就是居中固定显示，取消了 ScrollView